### PR TITLE
Set an appropriate image size for the screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,40 +10,67 @@ It is open source, free, and does not display adverts or pester you for a donati
       alt="Get it on F-Droid"
       height="80">](https://f-droid.org/packages/uk.co.yahoo.p1rpp.calendartrigger/)
 
-This is the screen displayed when you start up the UI
-![CalendarTrigger](./assets/StartScreen.png)
+This is the screen displayed when you start up the UI:
 
-This is the screen displayed when you select Debugging from the menu
-![CalendarTrigger](./assets/DebuggingScreen.png)
+<img src="./assets/StartScreen.png"
+     alt="StartScreen"
+     height=600em>
+
+This is the screen displayed when you select Debugging from the menu:
+
+<img src="./assets/DebuggingScreen.png"
+     alt="DebuggingScreen"
+     height=600em>
 
 CalendarTrigger supports classes of events. Events can be classified by the calendar which they are in, the presence of a specified string in the event name or the event location or the event description, whether the event is busy, whether the event is recurrent, whether the user is the event's organiser, whether the event is public or private, whether the event has attendees, or any combination of these conditions.
 
-This is the screen displayed when you select NEW EVENT CLASS
-![CalendarTrigger](./assets/NewClassScreen.png)
+This is the screen displayed when you select NEW EVENT CLASS:
 
-This is the screen displayed after creating a new class or if you select a class to be edited from the menu
-![CalendarTrigger](./assets/ExampleScreen.png)
+<img src="./assets/NewClassScreen.png"
+     alt="NewClassScreen"
+     height=600em>
 
-This is the screen to define the conditions for an event to be in a class
-![CalendarTrigger](./assets/DefineClassScreen.png)
+This is the screen displayed after creating a new class or if you select a class to be edited from the menu:
+
+<img src="./assets/ExampleScreen.png"
+     alt="ExampleScreen"
+     height=600em>
+
+This is the screen to define the conditions for an event to be in a class:
+
+<img src="./assets/DefineClassScreen.png"
+     alt="DefineClassScreen"
+     height=600em>
 
 At a fixed interval (possibly zero) before the start of an event, CalendarTrigger can set the ringer to mute or vibrate or set Do Not Disturb mode on Android versions which support it, or show a notification and optionally play a sound, or any combination of these actions. If the event start action does not change the ringer state or play a sound, no notification will be shown. I may add other actions in the future. Event start actions can be delayed until the device is in a particular orientation or being charged by a particular type of charger or not being charged at all. This can be useful to set a sleep mode at night. If the event start action mutes the audio, any sound played will of course not be audible. An event can be in more than one class, so it is possible to play an audio reminder a few minutes before the start of an event and then mute the audio.
 
-This is the screen to define when CalendarTrigger does event start actions
-![CalendarTrigger](./assets/StartConditionScreen.png)
+This is the screen to define when CalendarTrigger does event start actions:
 
-This is the screen to define what event start actions CalendarTrigger does
-![CalendarTrigger](./assets/StartActionScreen.png)
+<img src="./assets/StartConditionScreen.png"
+     alt="StartConditionScreen"
+     height=600em>
+
+This is the screen to define what event start actions CalendarTrigger does:
+
+<img src="./assets/StartActionScreen.png"
+     alt="StartActionScreen"
+     height=600em>
 
 At a fixed interval (possibly zero) after the end of an event, CalendarTrigger can restore the original ringer state, or show a notification and optionally play a sound. If the event end action does not change the ringer state or play a sound, no notification will be shown. Again I may add other actions in the future. Event end actions can be delayed until the device has moved by a certain distance (if it has a location sensor) or until the person holding the device has taken a certain number of steps (if it has a step counter) or until the device is in a particular orientation. This can be useful if you don't know exactly when an event will end, and you want to unmute the ringer when you leave the room or leave the building or pick the device up.
 
 The duration of an event should be greater than zero: if it is zero, Android may awaken CalendarTrigger a short time before or after the start and end time of the event, and CalendarTrigger cannot tell whether the event has been dealt with or not.
 
-This is the screen to define when CalendarTrigger does event end actions: the step counter option is disabled because the emulator on which these screen shots were generated doesn't emulate a step counter
-![CalendarTrigger](./assets/EndConditionScreen.png)
+This is the screen to define when CalendarTrigger does event end actions (the step counter option is disabled because the emulator on which these screen shots were generated doesn't emulate a step counter):
 
-This is the screen to define what event end actions CalendarTrigger does
-![CalendarTrigger](./assets/EndActionScreen.png)
+<img src="./assets/EndConditionScreen.png"
+     alt="EndConditionScreen"
+     height=600em>
+
+This is the screen to define what event end actions CalendarTrigger does:
+
+<img src="./assets/EndActionScreen.png"
+     alt="EndActionScreen"
+     height=600em>
 
 If events which set ringer modes overlap, the "quietest" one wins. If an event end action would restore the previous ringer state, and the user has in the meantime set a "quieter" state, the user's set state wins. The quietness order is as in the selection list for event start actions.
 
@@ -56,10 +83,14 @@ The UI is available in English and French: the French version could probably be 
 Help with the French translations would be welcome, as would UI translations for other languages.
 
 ## Help information
+
 CalendarTrigger uses the convention that a long press on a user interface object (such as a button or a checkbox) will pop up some information (usually in a toast) explaining what it does. If an option is disabled because CalendarTrigger does not have the permissions it needs to do that function, a long press will explain which permission is needed to enable it. If an option is disabled because your device's operating system or hardware does not support it, a long press will dispaly a message saying so.
 
-This is a Screen showing a help information popup
-![CalendarTrigger](./assets/StartHelpScreen.png)
+This is a Screen showing a help information popup:
+
+<img src="./assets/StartHelpScreen.png"
+     alt="StartHelpScreen"
+     height=600em>
 
 Some more complicated behaviours are described in this README file.
 


### PR DESCRIPTION
Display the screenshots in a moderate size which doesn't interrupt the reading flow that much. Note that GFM doesn't provide any native image sizing capabilities, so we have to fall back on good old HTML. I'm using the relative unit `em` so that the images will be displayed nicely on high DPI environments, too.